### PR TITLE
Let load in GHCi use the same window

### DIFF
--- a/Commands/Load in GHCi (New Tab).tmCommand
+++ b/Commands/Load in GHCi (New Tab).tmCommand
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>beforeRunningCommand</key>
+	<string>nop</string>
+	<key>command</key>
+	<string>#!/bin/bash
+
+THASKELL=${TM_HASKELL:-ghci}
+
+esc () {
+STR="$1" ruby &lt;&lt;"RUBY"
+   str = ENV['STR']
+   str = str.gsub(/'/, "'\\\\''")
+   str = str.gsub(/[\\"]/, '\\\\\\0')
+   print "'#{str}'"
+RUBY
+}
+
+PROCESS=ghc
+number=$(ps aux | grep -e $PROCESS | grep -v grep | wc -l | tr -s "\n")
+
+if [ $number -gt 0 ]
+    then
+		osascript &lt;&lt;- APPLESCRIPT
+		tell app "Terminal"
+		activate
+			tell application "System Events" to tell process "Terminal.app" to keystroke "t" using command down
+			do script "clear; cd $(esc "${TM_DIRECTORY}"); $THASKELL $(esc "${TM_FILEPATH}")"
+		end tell
+		APPLESCRIPT
+		
+else
+	osascript &lt;&lt;- APPLESCRIPT
+	tell app "Terminal"
+		launch
+		activate
+		do script "clear; cd $(esc "${TM_DIRECTORY}"); $THASKELL $(esc "${TM_FILEPATH}")"
+		set position of first window to {100, 100}
+	end tell
+	APPLESCRIPT
+fi</string>
+	<key>input</key>
+	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
+	<key>keyEquivalent</key>
+	<string>~@R</string>
+	<key>name</key>
+	<string>Load in GHCi (New Tab)</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>toolTip</string>
+	<key>scope</key>
+	<string>source.haskell</string>
+	<key>semanticClass</key>
+	<string>process.external.run.haskell</string>
+	<key>uuid</key>
+	<string>F46AE643-AEE9-49DC-AB93-AEE0104DC5E8</string>
+	<key>version</key>
+	<integer>2</integer>
+</dict>
+</plist>

--- a/Commands/Load in GHCi (New Window).tmCommand
+++ b/Commands/Load in GHCi (New Window).tmCommand
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>command</key>
+	<string>#!/bin/bash
+
+THASKELL=${TM_HASKELL:-ghci}
+
+esc () {
+STR="$1" ruby &lt;&lt;"RUBY"
+   str = ENV['STR']
+   str = str.gsub(/'/, "'\\\\''")
+   str = str.gsub(/[\\"]/, '\\\\\\0')
+   print "'#{str}'"
+RUBY
+}
+
+osascript &lt;&lt;- APPLESCRIPT
+tell app "Terminal"
+	launch
+	activate
+	do script "clear; cd $(esc "${TM_DIRECTORY}"); ghci $(esc "${TM_FILEPATH}")"
+	set position of first window to {100, 100}
+end tell
+APPLESCRIPT</string>
+	<key>input</key>
+	<string>none</string>
+	<key>keyEquivalent</key>
+	<string>@W</string>
+	<key>name</key>
+	<string>Load in GHCi (New Window)</string>
+	<key>outputLocation</key>
+	<string>toolTip</string>
+	<key>scope</key>
+	<string>source.haskell</string>
+	<key>semanticClass</key>
+	<string>process.external.run.haskell</string>
+	<key>uuid</key>
+	<string>F804D183-AEEC-4905-B849-7C5B125865EA</string>
+</dict>
+</plist>

--- a/Commands/Load in GHCi.tmCommand
+++ b/Commands/Load in GHCi.tmCommand
@@ -1,9 +1,16 @@
-#!/bin/bash
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>changed</key>
+	<dict>
+		<key>command</key>
+		<string>#!/bin/bash
 
 THASKELL=${TM_HASKELL:-ghci}
 
 esc () {
-STR="$1" ruby <<"RUBY"
+STR="$1" ruby &lt;&lt;"RUBY"
    str = ENV['STR']
    str = str.gsub(/'/, "'\\\\''")
    str = str.gsub(/[\\"]/, '\\\\\\0')
@@ -16,48 +23,29 @@ number=$(ps aux | grep -e $PROCESS | grep -v grep | wc -l | tr -s "\n")
 
 if [ $number -gt 0 ]
     then
-		osascript <<- APPLESCRIPT
+		osascript &lt;&lt;- APPLESCRIPT
 		tell app "Terminal"
 		activate
 			set winID to ID of window 1 -- get the ID of the frontmost window
 		  	do script ":quit" in window ID winID 
-			do script "clear; cd $(esc "${TM_DIRECTORY}"); ghci $(esc "${TM_FILEPATH}")" in window ID winID 
+			do script "clear; cd $(esc "${TM_DIRECTORY}"); $THASKELL $(esc "${TM_FILEPATH}")" in window ID winID 
 		end tell
 		APPLESCRIPT
 		
 else
-	osascript <<- APPLESCRIPT
+	osascript &lt;&lt;- APPLESCRIPT
 	tell app "Terminal"
 		launch
 		activate
-		do script "clear; cd $(esc "${TM_DIRECTORY}"); ghci $(esc "${TM_FILEPATH}")"
+		do script "clear; cd $(esc "${TM_DIRECTORY}"); $THASKELL $(esc "${TM_FILEPATH}")"
 		set position of first window to {100, 100}
 	end tell
 	APPLESCRIPT
-fi
-
-</string>
-	<key>input</key>
-	<string>none</string>
-	<key>inputFormat</key>
-	<string>text</string>
-	<key>keyEquivalent</key>
-	<string>@R</string>
-	<key>name</key>
-	<string>Load in GHCi</string>
-	<key>outputCaret</key>
-	<string>afterOutput</string>
-	<key>outputFormat</key>
-	<string>text</string>
-	<key>outputLocation</key>
-	<string>toolTip</string>
-	<key>scope</key>
-	<string>source.haskell</string>
-	<key>semanticClass</key>
-	<string>process.external.run.haskell</string>
+fi</string>
+	</dict>
+	<key>isDelta</key>
+	<true/>
 	<key>uuid</key>
 	<string>2242C46C-153E-4EEB-B80B-A5398559D759</string>
-	<key>version</key>
-	<integer>2</integer>
 </dict>
 </plist>

--- a/Commands/Load in GHCi.tmCommand
+++ b/Commands/Load in GHCi.tmCommand
@@ -1,16 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>beforeRunningCommand</key>
-	<string>nop</string>
-	<key>command</key>
-	<string>#!/bin/bash
+#!/bin/bash
 
 THASKELL=${TM_HASKELL:-ghci}
 
 esc () {
-STR="$1" ruby &lt;&lt;"RUBY"
+STR="$1" ruby <<"RUBY"
    str = ENV['STR']
    str = str.gsub(/'/, "'\\\\''")
    str = str.gsub(/[\\"]/, '\\\\\\0')
@@ -18,14 +11,31 @@ STR="$1" ruby &lt;&lt;"RUBY"
 RUBY
 }
 
-osascript &lt;&lt;- APPLESCRIPT
-tell app "Terminal"
-	launch
-	activate
-	do script "clear; cd $(esc "${TM_DIRECTORY}"); ${THASKELL} $(esc "${TM_FILEPATH}")"
-	set position of first window to {100, 100}
-end tell
-APPLESCRIPT
+PROCESS=ghc
+number=$(ps aux | grep -e $PROCESS | grep -v grep | wc -l | tr -s "\n")
+
+if [ $number -gt 0 ]
+    then
+		osascript <<- APPLESCRIPT
+		tell app "Terminal"
+		activate
+			set winID to ID of window 1 -- get the ID of the frontmost window
+		  	do script ":quit" in window ID winID 
+			do script "clear; cd $(esc "${TM_DIRECTORY}"); ghci $(esc "${TM_FILEPATH}")" in window ID winID 
+		end tell
+		APPLESCRIPT
+		
+else
+	osascript <<- APPLESCRIPT
+	tell app "Terminal"
+		launch
+		activate
+		do script "clear; cd $(esc "${TM_DIRECTORY}"); ghci $(esc "${TM_FILEPATH}")"
+		set position of first window to {100, 100}
+	end tell
+	APPLESCRIPT
+fi
+
 </string>
 	<key>input</key>
 	<string>none</string>


### PR DESCRIPTION
If you need to load at a lot of .hs files one after one you will get loads of new terminal windows. I changed the Load in GHCi command to use only one terminal window.

Option to load in new Window is added(which uses the old load method)

And there is an option to open in new terminal tab(which is somehow buggy...)
