### PR TITLE
Add boundary characters to `module (.*) where` definitions

### DIFF
--- a/Syntaxes/Haskell.plist
+++ b/Syntaxes/Haskell.plist
@@ -47,7 +47,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(module)</string>
+			<string>\b(module)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -57,7 +57,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>(where)</string>
+			<string>\b(where)\b</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
Here's another small fix we found while deploying:

Without boundary characters like all the other `where` definitions, any variable called `moduleSomething` would trigger the `module` context.
