### PR TITLE
Fix list comprehension snippet

### DIFF
--- a/Snippets/List Comprehension.tmSnippet
+++ b/Snippets/List Comprehension.tmSnippet
@@ -7,7 +7,7 @@
 	<key>name</key>
 	<string>List Comprehension</string>
 	<key>scope</key>
-	<string>source.haskell constant.language.nil</string>
+	<string>source.haskell constant.language.empty-list</string>
 	<key>tabTrigger</key>
 	<string>[</string>
 	<key>uuid</key>


### PR DESCRIPTION
The scope for the empty list seems to have changed.
This change applies it, enabling the list comprehension snippet again.