### PR TITLE
Fix comments in module export list

### DIFF
--- a/Syntaxes/Haskell.plist
+++ b/Syntaxes/Haskell.plist
@@ -601,6 +601,10 @@
 					<key>name</key>
 					<string>meta.other.unknown.haskell</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
 			</array>
 		</dict>
 		<key>module_name</key>


### PR DESCRIPTION
Comments are now correctly highlighted in module export list.

See issue #15 for an example of bad highlighting.
