### PR TITLE
Fix control character syntax in strings

### DIFF
--- a/Syntaxes/Haskell.plist
+++ b/Syntaxes/Haskell.plist
@@ -311,7 +311,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\^[A-Z@\[\]\\\^_]</string>
+					<string>\\^[A-Z@\[\]\\\^_]</string>
 					<key>name</key>
 					<string>constant.character.escape.control.haskell</string>
 				</dict>
@@ -392,7 +392,7 @@
 					|US|SP|DEL|[abfnrtv\\\"'\&amp;]))		# Escapes
 			  | (\\o[0-7]+)								# Octal Escapes
 			  | (\\x[0-9A-Fa-f]+)						# Hexadecimal Escapes
-			  | (\^[A-Z@\[\]\\\^_])						# Control Chars
+			  | (\\^[A-Z@\[\]\\\^_])						# Control Chars
 			)
 			(')
 			</string>

--- a/Syntaxes/Haskell.plist
+++ b/Syntaxes/Haskell.plist
@@ -311,7 +311,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\\^[A-Z@\[\]\\\^_]</string>
+					<string>\\\^[A-Z@\[\]\\\^_]</string>
 					<key>name</key>
 					<string>constant.character.escape.control.haskell</string>
 				</dict>
@@ -392,7 +392,7 @@
 					|US|SP|DEL|[abfnrtv\\\"'\&amp;]))		# Escapes
 			  | (\\o[0-7]+)								# Octal Escapes
 			  | (\\x[0-9A-Fa-f]+)						# Hexadecimal Escapes
-			  | (\\^[A-Z@\[\]\\\^_])						# Control Chars
+			  | (\\\^[A-Z@\[\]\\\^_])						# Control Chars
 			)
 			(')
 			</string>


### PR DESCRIPTION
A string with a control character, such as "foo \^A bar", will now highlight correctly. The problem was that the caret (^) was escaped, when the backslash used to escape it needed to be escaped itself.